### PR TITLE
Add letters `\dj \Dj`

### DIFF
--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -597,6 +597,10 @@
 
 \tdef\texttilde{\@u007e}
 
+\tdef\dj{\@u0111}
+
+\tdef\Dj{\@u0110}
+
 \tdef\smallskip{\@par}
 
 \tdef\medskip{\@par}

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -597,9 +597,9 @@
 
 \tdef\texttilde{\@u007e}
 
-\tdef\dj{\@u0111}
+\pdef\dj{\@u0111}
 
-\tdef\Dj{\@u0110}
+\pdef\Dj{\@u0110}
 
 \tdef\smallskip{\@par}
 


### PR DESCRIPTION
đ is used for non-exact differential forms in physics.