### PR TITLE
footnote reverse link

### DIFF
--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1197,9 +1197,9 @@
 }
 
 \pdef\@footnoteorigin{%
-    \@inc{g.ctr-footnoteorigin}
+    \@inc{g.ctr-footnoteorigin}%
     \@@def\@currentlabel{^}%
-    \@@set{ref-prefix}{o}% 
+    \@@set{ref-prefix}{o}%
     \@@bmk%
     \@@label{footnote-origin:{g.ctr-footnoteorigin}}%
 }

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1146,6 +1146,8 @@
 
 \newcounter{actualfootnote}
 
+\newcounter{footnoteorigin}
+
 \def\@printfootnotes{}
 
 \def\@footnotemark{%
@@ -1185,20 +1187,18 @@
 }
 
 \def\@footnoteorigin{%
-    \@inc{g.ctr-footnote}%
-    {%
-        \@settrue{text-sup}%
-        \@@def\@currentlabel{^}%
-        \@@set{ref-prefix}{o}% 
-        \@@bmk%
-        \@@label{footnote-origin:{g.ctr-footnote}}%
-    }%
-    \@dec{g.ctr-footnote}%
+    \@inc{g.ctr-footnote}
+    \@@def\@currentlabel{^}%
+    \@@set{ref-prefix}{o}% 
+    \@@bmk%
+    \@@label{footnote-origin:{g.ctr-footnote}}%
+    \@dec{g.ctr-footnote}
 }
 
 \def\@footnoteoriginref{%
+    \@inc{g.ctr-footnoteorigin}
     \@settrue{text-sup}%
-    \@@set{ref-key}{footnote-origin:{g.ctr-footnote}}%
+    \@@set{ref-key}{footnote-origin:{g.ctr-footnoteorigin}}%
     \@ref{\thefootnote}%
     \ % space
     \@setfalse{text-sup}%

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1154,12 +1154,28 @@
         \@settrue{text-sup}%
         \@@set{ref-key}{footnote:{g.ctr-footnote}}%
         \@ref{\thefootnote}%
+    }%
+    \@dec{g.ctr-footnote}%
+}
+
+\def\@footnoteorigin{%
+    \@inc{g.ctr-footnote}%
+    {%
+        \@settrue{text-sup}%
         \@@def\@currentlabel{^}%
         \@@set{ref-prefix}{o}% 
         \@@bmk%
-        \@@label{footnote-origin:\thefootnote}%
+        \@@label{footnote-origin:{g.ctr-footnote}}%
     }%
     \@dec{g.ctr-footnote}%
+}
+
+\def\@footnoteoriginref{%
+    \@settrue{text-sup}%
+    \@@set{ref-key}{footnote-origin:{g.ctr-footnote}}%
+    \@ref{\thefootnote}%
+    \ % space
+    \@setfalse{text-sup}%
 }
 
 \def\@printfootnoteitem[#1][#2]{%
@@ -1169,8 +1185,6 @@
     \@@def\@currentlabel{#2}%
     \@@bmk%
     \@@label{footnote:#1}%
-    \@@set{ref-key}{footnote-origin:#2}%
-    \@ref{#2}%
     \@setfalse{text-sup}%
 }
 
@@ -1185,12 +1199,14 @@
 
 \let\footnotemark\@footnotemark
 
+\let\footnoteorigin\@footnoteorigin
+
 \def\footnotetext#1{%
     \@inc{g.ctr-footnote}%
     \@footnotetext{#1}%
 }
 
-\def\footnote#1{\footnotemark\footnotetext{#1}}
+\def\footnote#1{\footnotemark\@footnoteorigin\footnotetext{\@footnoteoriginref#1}}
 
 \def\printfootnotes{%
     {%

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1195,16 +1195,16 @@
     \@dec{g.ctr-footnote}
 }
 
-\def\@footnoteoriginref{%
-    \@inc{g.ctr-footnoteorigin}
-    \@settrue{text-sup}%
-    \@@set{ref-key}{footnote-origin:{g.ctr-footnoteorigin}}%
-    \@ref{\thefootnoteorigin}%
-    \ % space
-    \@setfalse{text-sup}%
+\def\@footnoteoriginref#1{%
+    {
+        \@inc{g.ctr-footnoteorigin}
+        \@@set{ref-key}{footnote-origin:{g.ctr-footnoteorigin}}%
+        \@ref{\thefootnoteorigin}%
+    }
+    #1
 }
 
-\def\footnote#1{\footnotemark\@footnoteorigin\footnotetext{\@footnoteoriginref#1}}
+\def\footnote#1{\footnotemark\@footnoteorigin\footnotetext{\@footnoteoriginref{#1}}}
 
 \def\printfootnotes{%
     {%

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1141,6 +1141,24 @@
 
 
 % ==========         FOOTNOTES          ==========
+\def\@rep#1#2{
+    \@@if{#2}{1}{
+        #1
+    }{}
+    \@@if{#2}{2}{
+        #1#1
+    }{}
+    \@@if{#2}{3}{
+        #1#1#1
+    }{}
+    \@@if{#2}{4}{
+        #1#1#1#1
+    }{}
+    \@@if{#2}{5}{
+        #1#1#1#1#1
+    }{}
+}
+
 
 \newcounter{footnote}
 
@@ -1148,7 +1166,11 @@
 
 \newcounter{footnoteorigin}
 
+\newcounter{footnoteoriginref}
+
 \def\@printfootnotes{}
+
+\def\@footnoteorigincollection{}
 
 \def\@footnotemark{%
     \@inc{g.ctr-footnote}%
@@ -1156,6 +1178,8 @@
         \@settrue{text-sup}%
         \@@set{ref-key}{footnote:{g.ctr-footnote}}%
         \@ref{\thefootnote}%
+        \@footnoteorigin%
+        \@patch\@footnoteorigincollection{\@footnoteoriginref}
     }%
     \@dec{g.ctr-footnote}%
 }
@@ -1176,7 +1200,9 @@
     \@defexpand\@patch\@printfootnotes{\theactualfootnote}%
     \@patch\@printfootnotes{][}%
     \@defexpand\@patch\@printfootnotes{\thefootnote}%
-    \@patch\@printfootnotes{]#1}%
+    \@patch\@printfootnotes{]}%
+    \@defexpand\@patch\@printfootnotes{\@footnoteorigincollection}
+    \@patch\@printfootnotes{#1}%
 }
 
 \let\footnotemark\@footnotemark
@@ -1184,30 +1210,30 @@
 \def\footnotetext#1{%
     \@inc{g.ctr-footnote}%
     \@footnotetext{#1}%
+    \def\@footnoteorigincollection{}
 }
 
-\def\@footnoteorigin{%
-    \@inc{g.ctr-footnote}
+\pdef\@footnoteorigin{%
+    \@inc{g.ctr-footnoteorigin}
     \@@def\@currentlabel{^}%
     \@@set{ref-prefix}{o}% 
     \@@bmk%
-    \@@label{footnote-origin:{g.ctr-footnote}}%
-    \@dec{g.ctr-footnote}
+    \@@label{footnote-origin:{g.ctr-footnoteorigin}}%
 }
 
-\def\@footnoteoriginref#1{%
+\def\@footnoteoriginref{%
     {
-        \@inc{g.ctr-footnoteorigin}
-        \@@set{ref-key}{footnote-origin:{g.ctr-footnoteorigin}}%
-        \@ref{\thefootnoteorigin}%
+        \@inc{g.ctr-footnoteoriginref}
+        \@@set{ref-key}{footnote-origin:{g.ctr-footnoteoriginref}}%
+        \@ref{\thefootnoteoriginref}%
     }
-    #1
 }
 
-\def\footnote#1{\footnotemark\@footnoteorigin\footnotetext{\@footnoteoriginref{#1}}}
+\def\footnote#1{\footnotemark\footnotetext{#1}}
 
 \def\printfootnotes{%
     {%
+        \@@set{g.ctr-footnoteoriginref}{0}%
         \@@set{g.list-classes}{footnotes}%
         \begin{@list}%
             \@printfootnotes%

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1152,7 +1152,7 @@
 
 \def\@printfootnotes{}
 
-\def\@footnoteorigincollection{}
+\gdef\@footnoteorigincollection{}
 
 \def\@footnotemark{%
     \@inc{g.ctr-footnote}%
@@ -1160,8 +1160,9 @@
         \@settrue{text-sup}%
         \@@set{ref-key}{footnote:{g.ctr-footnote}}%
         \@ref{\thefootnote}%
+        \@setfalse{text-sup}%
         \@footnoteorigin%
-        \@patch\@footnoteorigincollection{\@footnoteoriginref}
+        \@patch\@footnoteorigincollection{\@footnoteoriginref}%
     }%
     \@dec{g.ctr-footnote}%
 }
@@ -1192,7 +1193,7 @@
 \def\footnotetext#1{%
     \@inc{g.ctr-footnote}%
     \@footnotetext{#1}%
-    \def\@footnoteorigincollection{}
+    \gdef\@footnoteorigincollection{}%
 }
 
 \pdef\@footnoteorigin{%

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1154,6 +1154,10 @@
         \@settrue{text-sup}%
         \@@set{ref-key}{footnote:{g.ctr-footnote}}%
         \@ref{\thefootnote}%
+        \@@def\@currentlabel{^}%
+        \@@set{ref-prefix}{o}% 
+        \@@bmk%
+        \@@label{footnote-origin:\thefootnote}%
     }%
     \@dec{g.ctr-footnote}%
 }
@@ -1165,6 +1169,8 @@
     \@@def\@currentlabel{#2}%
     \@@bmk%
     \@@label{footnote:#1}%
+    \@@set{ref-key}{footnote-origin:#2}%
+    \@ref{#2}%
     \@setfalse{text-sup}%
 }
 

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1199,7 +1199,7 @@
     \@inc{g.ctr-footnoteorigin}
     \@settrue{text-sup}%
     \@@set{ref-key}{footnote-origin:{g.ctr-footnoteorigin}}%
-    \@ref{\thefootnote}%
+    \@ref{\thefootnoteorigin}%
     \ % space
     \@setfalse{text-sup}%
 }

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1141,24 +1141,6 @@
 
 
 % ==========         FOOTNOTES          ==========
-\def\@rep#1#2{
-    \@@if{#2}{1}{
-        #1
-    }{}
-    \@@if{#2}{2}{
-        #1#1
-    }{}
-    \@@if{#2}{3}{
-        #1#1#1
-    }{}
-    \@@if{#2}{4}{
-        #1#1#1#1
-    }{}
-    \@@if{#2}{5}{
-        #1#1#1#1#1
-    }{}
-}
-
 
 \newcounter{footnote}
 
@@ -1201,7 +1183,7 @@
     \@patch\@printfootnotes{][}%
     \@defexpand\@patch\@printfootnotes{\thefootnote}%
     \@patch\@printfootnotes{]}%
-    \@defexpand\@patch\@printfootnotes{\@footnoteorigincollection}
+    \@defexpand\@patch\@printfootnotes{\@footnoteorigincollection}%
     \@patch\@printfootnotes{#1}%
 }
 

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -1158,26 +1158,6 @@
     \@dec{g.ctr-footnote}%
 }
 
-\def\@footnoteorigin{%
-    \@inc{g.ctr-footnote}%
-    {%
-        \@settrue{text-sup}%
-        \@@def\@currentlabel{^}%
-        \@@set{ref-prefix}{o}% 
-        \@@bmk%
-        \@@label{footnote-origin:{g.ctr-footnote}}%
-    }%
-    \@dec{g.ctr-footnote}%
-}
-
-\def\@footnoteoriginref{%
-    \@settrue{text-sup}%
-    \@@set{ref-key}{footnote-origin:{g.ctr-footnote}}%
-    \@ref{\thefootnote}%
-    \ % space
-    \@setfalse{text-sup}%
-}
-
 \def\@printfootnoteitem[#1][#2]{%
     \@@set{ref-prefix}{f}%
     \@item[#2.]%
@@ -1199,11 +1179,29 @@
 
 \let\footnotemark\@footnotemark
 
-\let\footnoteorigin\@footnoteorigin
-
 \def\footnotetext#1{%
     \@inc{g.ctr-footnote}%
     \@footnotetext{#1}%
+}
+
+\def\@footnoteorigin{%
+    \@inc{g.ctr-footnote}%
+    {%
+        \@settrue{text-sup}%
+        \@@def\@currentlabel{^}%
+        \@@set{ref-prefix}{o}% 
+        \@@bmk%
+        \@@label{footnote-origin:{g.ctr-footnote}}%
+    }%
+    \@dec{g.ctr-footnote}%
+}
+
+\def\@footnoteoriginref{%
+    \@settrue{text-sup}%
+    \@@set{ref-key}{footnote-origin:{g.ctr-footnote}}%
+    \@ref{\thefootnote}%
+    \ % space
+    \@setfalse{text-sup}%
 }
 
 \def\footnote#1{\footnotemark\@footnoteorigin\footnotetext{\@footnoteoriginref#1}}


### PR DESCRIPTION
在每处footnote调用处添加一个`footnote-origin:\thefootnote`的label，在`printfoot`处引用此label

生成效果如下

<img width="516" alt="image" src="https://github.com/banana-space/btex/assets/32606147/86fe2baf-60d2-43c3-89ec-2fddec5c9fd9">

点击`^`将会返回脚标源头