### PR TITLE
margin note implementation with sample css

### DIFF
--- a/src/lib/Element.ts
+++ b/src/lib/Element.ts
@@ -7,6 +7,7 @@ import { HeaderElement } from './elements/HeaderElement';
 import { ImageElement } from './elements/ImageElement';
 import { ListElement } from './elements/ListElement';
 import { MathElement } from './elements/MathElement';
+import { MarginnoteElement} from './elements/MarginnoteElement';
 import { ParagraphElement } from './elements/ParagraphElement';
 import { ReferenceElement } from './elements/ReferenceElement';
 import { TableElement } from './elements/TableElement';
@@ -54,6 +55,7 @@ export const Containers: { [name: string]: ContainerConstructor } = {
   header: HeaderElement,
   list: ListElement,
   math: MathElement,
+  marginnote: MarginnoteElement,
   table: TableElement,
   toc: TabelOfContentElement,
   ref: ReferenceElement,

--- a/src/lib/elements/MarginnoteElement.ts
+++ b/src/lib/elements/MarginnoteElement.ts
@@ -1,0 +1,54 @@
+import { Context } from '../Context';
+import { ContainerElement, RenderOptions } from '../Element';
+import { Token } from '../Token';
+import { ParagraphElement } from './ParagraphElement';
+
+export class MarginnoteElement implements ContainerElement {
+  name: 'marginnote' = 'marginnote';
+  paragraph: ParagraphElement = new ParagraphElement();
+  isInline: boolean = true;
+  marginnotemark?: string = ''
+
+
+  constructor() {}
+
+  isEmpty(): boolean {
+    return !this.paragraph.getText();
+  }
+
+  getText(): string {
+    return this.paragraph.getText();
+  }
+
+  normalise() {
+    this.paragraph.normalise();
+  }
+
+  enter(context: Context, initiator: Token): void {
+    this.marginnotemark = context.get('marginnote-mark', true);
+    // do nothing
+  }
+
+  event(arg: string, context: Context, initiator: Token) {
+    switch(arg)
+    {
+      case 'par':
+        context.throw('NO_PARAGRAPHS_IN_INLINE_MODE', initiator);
+        return false;
+    }
+    context.throw('UNKNOWN_EVENT', initiator, arg);
+    return false;
+  }
+
+  render(options?: RenderOptions): HTMLElement[] {
+    let span = document.createElement('sup');
+    span.setAttribute('class', 'marginnote');
+    if(this.marginnotemark)
+      span.append(this.marginnotemark)
+    let marginnote = document.createElement('small');
+    marginnote.setAttribute('class', 'marginnotebody');
+    marginnote.append(...this.paragraph.renderInner(options));
+    span.appendChild(marginnote)
+    return [span]
+  }
+}

--- a/src/lib/init.btx
+++ b/src/lib/init.btx
@@ -971,6 +971,22 @@
 
 \envdef{equation*}{}{\[}{\]}
 
+% ==========         MARGINNOTES          ==========
+\newcounter{marginnote}
+
+\def\enablemarginnote{%
+    \def\@marginnote#1#2{%
+        \@inc{g.ctr-marginnote}%
+        \@@set{marginnote-mark}{\@@cmd{themarginnote}}%
+        \@@enter{marginnote}%
+        \@bf\@rm#1 \themarginnote.\@md\ #2%
+        \@@exit{marginnote}%
+    }%
+
+    \def\marginnote#1{%
+        \@marginnote{\marginnotename}{#1}%
+    }%
+}%
 
 % ==========           FIGURES          ==========
 
@@ -1446,6 +1462,7 @@
 \def\tocname{目录}
 \def\figname{图}
 \def\tablename{表}
+\def\marginnotename{注}
 
 \def\@english{%
     \@@def\theoremname{Theorem}%
@@ -1461,6 +1478,7 @@
     \@@def\tocname{Contents}%
     \@@def\figname{Figure}
     \@@def\tablename{Table}
+    \@@def\marginnotename{Note}
 }
 
 \def\english{\setlanguage{en}\@english}

--- a/test/test.css
+++ b/test/test.css
@@ -84,3 +84,41 @@ span.display-math span.equation-tag-right {
   flex-shrink: 0;
   flex-grow: 0;
 }
+
+.marginnotebody {
+    font-size: 80%;
+    position: relative;
+}
+/* Wide viewport */
+@media (min-width: 1400px) {
+    .marginnotebody {
+        display: block;
+        float: right;
+        clear: right;
+        margin-right: -23vw;
+        text-align: left;
+
+        top: -1rem;
+        width: 20vw;
+        margin-top: 1rem;
+    }
+}
+
+@media (max-width: 1400px) {
+  .marginnotebody {
+      display: block;
+      float: left;
+      clear: right;
+      text-align: left;
+      margin-left: 2rem;
+      margin-right: 2rem;
+      width: 100%;
+  }
+}
+
+@media (min-width: 1400px) {
+/* Highlight the sidenote when mouse hovers on the sidenote number in body. */
+.marginnote:hover .marginnotebody {
+    background-color: yellow;
+}
+} 


### PR DESCRIPTION
主要的实现用到了test.css中的修改部分
宽屏实现效果如下
没有像footnote一样的跳转但是hover highlight
![image](https://github.com/banana-space/btex/assets/32606147/8f5751d0-a7a5-4d34-b4b9-96aaae63c9e6)
在窄屏效果如下
![image](https://github.com/banana-space/btex/assets/32606147/6b675aac-95c1-415f-a43c-30809eebf18f)
